### PR TITLE
Add deterministic multi-agent video pipeline scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# longshot-ai
+
+Longshot AI is a research-oriented scaffold for chaining specialized agents
+that turn a single prompt into a fully rendered video artifact. The repository
+prioritizes determinism, reproducibility, and modularity so experiments can be
+replayed while swapping underlying media models.
+
+## Goals
+
+- Orchestrate a pipeline that converts a natural-language prompt into a
+  structured workflow plan.
+- Produce deterministic keyframe schedules that downstream animation engines
+  can consume.
+- Provide lightweight adapters for animation and audio subsystems.
+- Assemble intermediate outputs into a reproducible media artifact manifest.
+
+## Repository layout
+
+```
+longshot-ai/
+├── README.md
+├── requirements.txt
+├── src/
+│   └── longshot/
+│       ├── __init__.py
+│       ├── animator.py
+│       ├── audio_agent.py
+│       ├── compositor.py
+│       ├── config.py
+│       ├── keyframer.py
+│       └── orchestrator.py
+└── tests/
+    ├── __init__.py
+    ├── test_keyframe_schedule.py
+    └── test_pipeline_behavior.py
+```
+
+## Quickstart
+
+Install dependencies and run the test suite to verify the scaffold:
+
+```
+pip install -r requirements.txt
+pytest -q
+```
+
+## Usage
+
+```python
+from longshot.pipeline import build_pipeline, PipelineConfig
+
+config = PipelineConfig.from_prompt(
+    prompt="Epic continuous shot of a cyberpunk DJ in a neon-lit club, 120 seconds"
+)
+pipeline = build_pipeline(config)
+artifact = pipeline.run()
+print(artifact.manifest_path)
+```
+
+The default pipeline returns deterministic, metadata-only artifacts that can be
+fed into external rendering engines. Integrators can subclass individual agent
+adapters to call proprietary services while keeping the deterministic plan for
+regression testing.
+
+## License
+
+This project is licensed under the MIT License.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# No external dependencies are required for the core scaffold.

--- a/src/longshot/__init__.py
+++ b/src/longshot/__init__.py
@@ -1,0 +1,12 @@
+"""Top-level package for the Longshot AI orchestration scaffold."""
+
+from .config import AgentConfig, PipelineConfig
+from .pipeline import Pipeline, PipelineArtifacts, build_pipeline
+
+__all__ = [
+    "AgentConfig",
+    "PipelineConfig",
+    "Pipeline",
+    "PipelineArtifacts",
+    "build_pipeline",
+]

--- a/src/longshot/animator.py
+++ b/src/longshot/animator.py
@@ -1,0 +1,45 @@
+"""Animation planning utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from .keyframer import Keyframe
+
+
+@dataclass(frozen=True)
+class AnimationSegment:
+    """Description of how to transition between two keyframes."""
+
+    start_index: int
+    end_index: int
+    technique: str
+
+
+def plan_animation(keyframes: List[Keyframe]) -> List[AnimationSegment]:
+    """Produce animation segments connecting adjacent keyframes.
+
+    Args:
+        keyframes: Ordered keyframe list.
+
+    Returns:
+        List of :class:`AnimationSegment` covering each adjacent pair. The
+        technique is selected deterministically based on index parity so unit
+        tests can assert the plan.
+    """
+
+    if not keyframes:
+        return []
+
+    segments: List[AnimationSegment] = []
+    for idx in range(len(keyframes) - 1):
+        technique = "morph" if idx % 2 == 0 else "camera-pan"
+        segments.append(
+            AnimationSegment(
+                start_index=keyframes[idx].index,
+                end_index=keyframes[idx + 1].index,
+                technique=technique,
+            )
+        )
+    return segments

--- a/src/longshot/audio_agent.py
+++ b/src/longshot/audio_agent.py
@@ -1,0 +1,28 @@
+"""Audio planning utilities for the Longshot pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AudioTrack:
+    """Simple audio track metadata."""
+
+    style: str
+    duration_seconds: int
+
+
+def design_audio(style_hint: str, duration_seconds: int) -> AudioTrack:
+    """Return deterministic audio metadata based on the style hint.
+
+    Args:
+        style_hint: Free-form style descriptor from the prompt.
+        duration_seconds: Target length of the audio track.
+
+    Returns:
+        :class:`AudioTrack` metadata with a normalized style tag.
+    """
+
+    normalized = style_hint.lower().replace(" ", "-") or "ambient"
+    return AudioTrack(style=normalized, duration_seconds=duration_seconds)

--- a/src/longshot/compositor.py
+++ b/src/longshot/compositor.py
@@ -1,0 +1,79 @@
+"""Manifest composition utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Tuple
+
+from .animator import AnimationSegment
+from .audio_agent import AudioTrack
+from .keyframer import Keyframe
+
+
+@dataclass(frozen=True)
+class ManifestEntry:
+    """Single artifact entry in the composed manifest."""
+
+    kind: str
+    payload: dict
+
+
+@dataclass(frozen=True)
+class Manifest:
+    """Composable manifest that can be serialized to JSON in calling code."""
+
+    entries: tuple[ManifestEntry, ...]
+
+
+def compose_manifest(
+    keyframes: Iterable[Keyframe],
+    segments: Iterable[AnimationSegment],
+    audio: AudioTrack,
+    *,
+    manifest_path: Path,
+) -> Manifest:
+    """Combine pipeline outputs into a manifest structure.
+
+    Args:
+        keyframes: Sequence of generated keyframes.
+        segments: Sequence of animation segments.
+        audio: Planned audio track metadata.
+        manifest_path: Filesystem location where downstream code should persist
+            the manifest. No write occurs in this function to preserve purity.
+
+    Returns:
+        Manifest describing the pipeline outputs.
+    """
+
+    keyframe_tuple: Tuple[Keyframe, ...] = tuple(keyframes)
+    segment_tuple: Tuple[AnimationSegment, ...] = tuple(segments)
+
+    entries = [
+        ManifestEntry(
+            kind="keyframes",
+            payload={
+                "count": len(keyframe_tuple),
+            },
+        ),
+        ManifestEntry(
+            kind="animation_segments",
+            payload={
+                "count": len(segment_tuple),
+            },
+        ),
+        ManifestEntry(
+            kind="audio",
+            payload={
+                "style": audio.style,
+                "duration_seconds": audio.duration_seconds,
+            },
+        ),
+        ManifestEntry(
+            kind="manifest_reference",
+            payload={
+                "path": str(manifest_path),
+            },
+        ),
+    ]
+    return Manifest(entries=tuple(entries))

--- a/src/longshot/config.py
+++ b/src/longshot/config.py
@@ -1,0 +1,88 @@
+"""Configuration objects for the Longshot AI pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass(frozen=True)
+class AgentConfig:
+    """Configuration for a specific agent in the pipeline.
+
+    Attributes:
+        name: Canonical name of the agent implementation.
+        model: Optional model identifier or version tag.
+    """
+
+    name: str
+    model: str | None = None
+
+
+@dataclass(frozen=True)
+class KeyframeSpec:
+    """Declarative description of a keyframe produced by the orchestrator."""
+
+    index: int
+    timestamp: float
+    description: str
+
+
+@dataclass(frozen=True)
+class PipelineConfig:
+    """Container for the end-to-end pipeline configuration.
+
+    Attributes:
+        prompt: User provided natural-language description.
+        duration_seconds: Target duration for the final video.
+        agents: Ordered list of agent configurations to execute.
+        seed: RNG seed used to keep pipeline outputs deterministic.
+    """
+
+    prompt: str
+    duration_seconds: int
+    agents: List[AgentConfig] = field(default_factory=list)
+    seed: int = 42
+
+    @classmethod
+    def from_prompt(
+        cls,
+        prompt: str,
+        duration_seconds: int | None = None,
+        *,
+        seed: int = 42,
+    ) -> "PipelineConfig":
+        """Derive a default pipeline configuration from a free-form prompt.
+
+        Args:
+            prompt: High-level description of the desired video.
+            duration_seconds: Optional target duration. Defaults to 60 seconds when
+                unspecified.
+            seed: RNG seed used to keep deterministic outputs.
+
+        Returns:
+            A fully populated :class:`PipelineConfig` with default agents.
+        """
+
+        clean_prompt = prompt.strip()
+        if not clean_prompt:
+            raise ValueError("prompt must be a non-empty string")
+
+        duration = duration_seconds or 60
+        if duration <= 0:
+            raise ValueError("duration_seconds must be positive")
+
+        agents = [
+            AgentConfig(name="orchestrator", model="gpt-5"),
+            AgentConfig(name="keyframer", model="nano-banana-v1"),
+            AgentConfig(name="animator", model="kling-2.1"),
+            AgentConfig(name="audio", model="riffusion"),
+            AgentConfig(name="compositor", model="ffmpeg"),
+        ]
+
+        return cls(
+            prompt=clean_prompt,
+            duration_seconds=duration,
+            agents=agents,
+            seed=seed,
+        )

--- a/src/longshot/keyframer.py
+++ b/src/longshot/keyframer.py
@@ -1,0 +1,38 @@
+"""Deterministic keyframe generation based on workflow plans."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from .orchestrator import WorkflowPlan
+
+
+@dataclass(frozen=True)
+class Keyframe:
+    """Concrete keyframe representation with normalized scene tokens."""
+
+    index: int
+    timestamp: float
+    tokens: List[str]
+
+
+def generate_keyframes(plan: WorkflowPlan) -> List[Keyframe]:
+    """Convert workflow keyframe specs into structured keyframes.
+
+    Args:
+        plan: Workflow plan produced by the orchestrator.
+
+    Returns:
+        Deterministic list of :class:`Keyframe` objects. Tokens are derived by
+        lower-casing the description and splitting on whitespace to facilitate
+        reproducible downstream comparisons.
+    """
+
+    keyframes: List[Keyframe] = []
+    for spec in plan.keyframes:
+        tokens = [token for token in spec.description.lower().split() if token]
+        keyframes.append(
+            Keyframe(index=spec.index, timestamp=spec.timestamp, tokens=tokens)
+        )
+    return keyframes

--- a/src/longshot/orchestrator.py
+++ b/src/longshot/orchestrator.py
@@ -1,0 +1,68 @@
+"""Utilities for planning a deterministic workflow from a prompt."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from .config import KeyframeSpec, PipelineConfig
+
+
+@dataclass(frozen=True)
+class WorkflowPlan:
+    """Structured plan output by the orchestrator.
+
+    Attributes:
+        prompt: Original user prompt used for planning.
+        duration_seconds: Target duration for the video.
+        keyframes: Ordered list of keyframe specifications that downstream
+            agents will elaborate on.
+    """
+
+    prompt: str
+    duration_seconds: int
+    keyframes: List[KeyframeSpec]
+
+
+def plan_workflow(config: PipelineConfig) -> WorkflowPlan:
+    """Derive a deterministic workflow plan from the provided configuration.
+
+    The current implementation splits the prompt into thematic fragments using
+    sentence boundaries and distributes them evenly across the timeline. The
+    approach avoids randomness to guarantee repeatable results for regression
+    testing.
+
+    Args:
+        config: Fully resolved pipeline configuration.
+
+    Returns:
+        A :class:`WorkflowPlan` containing the ordered keyframe schedule.
+    """
+
+    sentences = _split_prompt(config.prompt)
+    interval = config.duration_seconds / max(len(sentences), 1)
+    keyframes = [
+        KeyframeSpec(index=index, timestamp=round(interval * index, 3), description=segment)
+        for index, segment in enumerate(sentences)
+    ]
+    if not keyframes:
+        keyframes = [
+            KeyframeSpec(index=0, timestamp=0.0, description=config.prompt),
+        ]
+    return WorkflowPlan(
+        prompt=config.prompt,
+        duration_seconds=config.duration_seconds,
+        keyframes=keyframes,
+    )
+
+
+def _split_prompt(prompt: str) -> List[str]:
+    """Split a prompt into stable thematic segments.
+
+    The helper removes trailing punctuation and ensures the resulting segments
+    are non-empty. Splitting uses periods and semicolons because they are
+    frequent delimiters in creative prompts.
+    """
+
+    candidates = [segment.strip() for segment in prompt.replace(";", ".").split(".")]
+    return [segment for segment in candidates if segment]

--- a/src/longshot/pipeline.py
+++ b/src/longshot/pipeline.py
@@ -1,0 +1,77 @@
+"""High-level pipeline wiring for the Longshot AI scaffold."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .animator import AnimationSegment, plan_animation
+from .audio_agent import AudioTrack, design_audio
+from .compositor import Manifest, compose_manifest
+from .config import PipelineConfig
+from .keyframer import Keyframe, generate_keyframes
+from .orchestrator import WorkflowPlan, plan_workflow
+
+
+@dataclass(frozen=True)
+class PipelineArtifacts:
+    """Container for the artifacts returned by the pipeline."""
+
+    plan: WorkflowPlan
+    keyframes: tuple[Keyframe, ...]
+    animation: tuple[AnimationSegment, ...]
+    audio: AudioTrack
+    manifest: Manifest
+    manifest_path: Path
+
+
+class Pipeline:
+    """Deterministic orchestration pipeline."""
+
+    def __init__(self, config: PipelineConfig, *, manifest_path: Path | None = None) -> None:
+        """Store configuration and derived manifest path.
+
+        Args:
+            config: Pipeline configuration.
+            manifest_path: Optional path for downstream manifest persistence. A
+                default inside the current working directory is used when
+                omitted.
+        """
+
+        self._config = config
+        self._manifest_path = manifest_path or Path("artifacts/manifest.jsonl")
+
+    @property
+    def config(self) -> PipelineConfig:
+        """Return the pipeline configuration."""
+
+        return self._config
+
+    def run(self) -> PipelineArtifacts:
+        """Execute the pipeline end to end returning deterministic artifacts."""
+
+        plan = plan_workflow(self._config)
+        keyframes = tuple(generate_keyframes(plan))
+        animation = tuple(plan_animation(list(keyframes)))
+        audio_style_hint = plan.keyframes[0].description if plan.keyframes else self._config.prompt
+        audio = design_audio(audio_style_hint, self._config.duration_seconds)
+        manifest = compose_manifest(
+            keyframes,
+            animation,
+            audio,
+            manifest_path=self._manifest_path,
+        )
+        return PipelineArtifacts(
+            plan=plan,
+            keyframes=keyframes,
+            animation=animation,
+            audio=audio,
+            manifest=manifest,
+            manifest_path=self._manifest_path,
+        )
+
+
+def build_pipeline(config: PipelineConfig, *, manifest_path: Path | None = None) -> Pipeline:
+    """Construct a :class:`Pipeline` with the provided configuration."""
+
+    return Pipeline(config=config, manifest_path=manifest_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Test configuration for ensuring src/ is importable."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SRC_PATH = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))

--- a/tests/test_keyframe_schedule.py
+++ b/tests/test_keyframe_schedule.py
@@ -1,0 +1,30 @@
+"""Invariants for the deterministic keyframe schedule."""
+
+from __future__ import annotations
+
+from longshot.config import PipelineConfig
+from longshot.keyframer import generate_keyframes
+from longshot.orchestrator import plan_workflow
+
+
+def test_keyframe_timestamps_monotonic() -> None:
+    """Keyframe timestamps should be monotonic non-decreasing."""
+
+    config = PipelineConfig.from_prompt(
+        "Scene one. Scene two. Scene three.", duration_seconds=90
+    )
+    plan = plan_workflow(config)
+    keyframes = generate_keyframes(plan)
+    timestamps = [keyframe.timestamp for keyframe in keyframes]
+    assert timestamps == sorted(timestamps)
+    assert timestamps[0] == 0.0
+
+
+def test_keyframe_count_matches_sentences() -> None:
+    """Keyframe count should equal the number of sentences in the prompt."""
+
+    prompt = "First beat. Second beat. Third beat. Fourth beat."
+    config = PipelineConfig.from_prompt(prompt, duration_seconds=120)
+    plan = plan_workflow(config)
+    keyframes = generate_keyframes(plan)
+    assert len(keyframes) == 4

--- a/tests/test_pipeline_behavior.py
+++ b/tests/test_pipeline_behavior.py
@@ -1,0 +1,24 @@
+"""Behavioral tests for the end-to-end pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from longshot.pipeline import PipelineConfig, build_pipeline
+
+
+def test_pipeline_produces_manifest(tmp_path: Path) -> None:
+    """End-to-end pipeline should produce a manifest with consistent metadata."""
+
+    config = PipelineConfig.from_prompt(
+        "DJ in neon club. Crowd reacts. Camera pulls back.", duration_seconds=90
+    )
+    manifest_path = tmp_path / "manifest.jsonl"
+    pipeline = build_pipeline(config, manifest_path=manifest_path)
+    artifacts = pipeline.run()
+
+    assert artifacts.manifest_path == manifest_path
+    assert artifacts.audio.duration_seconds == config.duration_seconds
+    assert artifacts.keyframes[0].timestamp == 0.0
+    assert len(artifacts.animation) == len(artifacts.keyframes) - 1
+    assert artifacts.manifest.entries[-1].payload["path"] == str(manifest_path)


### PR DESCRIPTION
## Summary
- introduce a research-focused scaffold for orchestrating prompt-to-video agent pipelines
- provide deterministic planning modules for orchestration, keyframing, animation, audio, and manifest composition
- add invariants and behavioral pytest coverage to keep the pipeline reproducible

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1500075b48321945ee82a3a9b3329