### PR TITLE
Fix CI workflow to use Python 3.13 and install pytest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest
+
+      - name: Run test suite
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
## Summary
- set the CI workflow to use Python 3.13, matching the project target
- install pytest alongside requirements to ensure the test runner is available
- add a .gitignore entry to keep bytecode artifacts out of version control

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1539144d0832189c434730f4d0f54